### PR TITLE
chore(deps): intègre TailwindCSS et met à jour la configuration associée

### DIFF
--- a/.junie/guidelines.md
+++ b/.junie/guidelines.md
@@ -1,0 +1,332 @@
+# Guide de style et bonnes pratiques Angular 20+
+
+## Objectif
+
+Fournir une référence moderne, claire et générique pour structurer, coder, tester et livrer des applications Angular 20+.
+
+## Outils et commandes (à adapter selon votre gestionnaire de paquets)
+
+### Démarrer le serveur de dev
+- **Vite**: `pnpm dev` / `npm run dev`
+- **CLI Angular**: `ng serve`
+
+### Build
+- **Build production**: `pnpm build`
+- **Build watch**: `pnpm watch`
+
+### Tests unitaires
+- **Tests**: `pnpm test` (Vitest recommandé avec `@analogjs/vitest-angular`)
+- **Fichiers de test**: `*.spec.ts`
+- **Setup global**: `src/test-setup.ts`
+
+### Qualité de code
+- **Lint**: `pnpm lint`
+- **Lint + fix**: `pnpm lint:fix`
+- **Format**: `pnpm prettier`
+- **Vérifier le format**: `pnpm prettier:check`
+
+**Recommandé**: hooks pré-commit (Husky + lint-staged) pour lancer lint, prettier:check et typecheck (`tsc --noEmit`).
+
+## Architecture et structure
+
+### Technologies
+- **Framework**: Angular 20+
+- **Dev server/build**: Vite (via `@analogjs/vite-plugin-angular`) recommandé
+- **Tests**: Vitest (+ `@analogjs/vitest-angular`)
+- **Styles**: TailwindCSS possible; PostCSS recommandé
+- **TypeScript**: configuration stricte (`"strict": true`)
+
+### Structure de projet
+
+- **`core/`**: services transverses (auth, http, thème), guards, interceptors, utils, configuration d'app.
+- **`features/`**: fonctionnalités verticales (domaines métier) avec composants/pages, routes et services spécifiques.
+- **`shared/`**: UI réutilisable (composants, directives, pipes), helpers UI, et un emplacement unique pour modèles/interfaces partagés (ex. `shared/models`).
+
+**Règle**: un seul emplacement pour interfaces/models afin d'éviter les duplications.
+
+**Barrels** (`index.ts`): autorisés avec parcimonie; éviter les cycles.
+
+### Conventions de nommage (officielles Angular)
+- **Composants**: `feature-name.component.ts`
+- **Services**: `feature-name.service.ts`
+- **Guards**: `feature-name.guard.ts`
+- **Directives**: `feature-name.directive.ts`
+- **Pipes**: `feature-name.pipe.ts`
+- **Modèles/Types**: `feature-name.model.ts` (ou `.types.ts`)
+- **Tests**: `feature-name.component.spec.ts` (selon l'artefact)
+
+Fichiers en **kebab-case**; classes en **PascalCase**.
+
+## Philosophie moderne (Angular 20+)
+
+### Architecture standalone
+- Tous les composants/directives/pipes sont **standalone**.
+- Déclarez explicitement `standalone: true` dans le décorateur (même si la CLI le génère).
+- Les NgModules ne sont plus nécessaires pour organiser le code.
+
+### Réactivité par signaux
+- `signal()` pour l'état local, `computed()` pour l'état dérivé, `effect()` pour les effets.
+- `set()` et `update()` par défaut; `mutate()` uniquement si un gain de performance est justifié (documenter la décision).
+
+### Templates déclaratifs
+- Utiliser le nouveau contrôle de flux: `@if`, `@for`, `@switch` (toujours fournir `track` dans `@for`).
+- Préférer les bindings natifs `[class.xxx]` et `[style.xxx]`; utiliser `ngClass`/`ngStyle` quand plusieurs classes/styles dynamiques sont nécessaires.
+
+### Injection de dépendances (DI)
+- `inject()` privilégié dans services, guards, interceptors, factories et fonctions.
+- Injection par constructeur autorisée et lisible dans les composants/directives.
+- Services globaux: `providedIn: 'root'`.
+
+## Composants
+
+### Bonnes pratiques
+- **Responsabilité unique**; découpage par fonctionnalités.
+- Toujours `changeDetection: ChangeDetectionStrategy.OnPush`.
+- **Inputs/Outputs**: préférer `input()` et `output()` aux décorateurs classiques.
+- **Two-way binding**: `model()` si pertinent.
+- **Host bindings/listeners**: utiliser la clé `host` du décorateur `@Component`.
+- **Images statiques**: utiliser `NgOptimizedImage` avec `width`/`height` explicites (ou `fill`).
+
+### Exemple
+
+```typescript
+import {
+  Component,
+  ChangeDetectionStrategy,
+  input,
+  output,
+  model,
+} from '@angular/core';
+
+@Component({
+  selector: 'feature-widget',
+  standalone: true,
+  template: `
+    @if (visible()) {
+      <div [class.active]="active()" [style.color]="color()">
+        {{ title() }}
+      </div>
+    }
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    '[attr.aria-busy]': 'loading()',
+  },
+})
+export class FeatureWidgetComponent {
+  title = input.required<string>();
+  visible = model<boolean>(true);
+  active = input(false);
+  color = input<string>('inherit');
+  loading = input(false);
+  toggled = output<boolean>();
+}
+```
+
+## Gestion de l'état
+
+- Utiliser des **signaux** pour l'UI et l'état local/partagé via services.
+- Conserver les **Observables** aux frontières (HttpClient, WebSocket); convertir via `toSignal()` si utile.
+- **Immutabilité** par défaut avec `set`/`update`; `mutate` rare et justifié.
+
+## Routage
+
+### Stratégies de lazy loading
+- **Pages simples**: lazy-load via `loadComponent`.
+- **Features complexes** (enfants, layouts, multiples guards): lazy-load via `loadChildren`.
+- Préférer les **guards fonctionnels**; utiliser `canMatch` pour filtrer dès la résolution de route.
+
+### Exemple
+
+```typescript
+import { Routes, CanMatchFn } from '@angular/router';
+import { inject } from '@angular/core';
+import { AuthService } from '@core/services/auth.service';
+
+export const adminGuard: CanMatchFn = () => {
+  const auth = inject(AuthService);
+  return auth.isAdmin(); // boolean, UrlTree ou Promise/Observable
+};
+
+export const routes: Routes = [
+  {
+    path: 'dashboard',
+    loadComponent: () =>
+      import('@features/dashboard/dashboard.page').then(m => m.DashboardPageComponent),
+  },
+  {
+    path: 'admin',
+    canMatch: [adminGuard],
+    loadChildren: () =>
+      import('@features/admin/admin.routes').then(m => m.ADMIN_ROUTES),
+  },
+];
+```
+
+## HTTP client moderne
+
+### Configuration
+Fournir `HttpClient` lors du bootstrap (ex. `main.ts`):
+
+```typescript
+provideHttpClient(withFetch(), withInterceptors([authInterceptor, errorInterceptor]))
+```
+
+Typage strict des réponses; gestion d'erreurs centralisée (401, 403, 5xx) via interceptors.
+
+### Exemple d'interceptor fonctionnel
+
+```typescript
+import { HttpInterceptorFn } from '@angular/common/http';
+import { catchError, throwError } from 'rxjs';
+
+export const errorInterceptor: HttpInterceptorFn = (req, next) =>
+  next(req).pipe(
+    catchError(err => {
+      // mapping d'erreurs, logs, redirections si besoin
+      return throwError(() => err);
+    })
+  );
+```
+
+### Bootstrap
+
+```typescript
+import { bootstrapApplication } from '@angular/platform-browser';
+import { provideHttpClient, withFetch, withInterceptors } from '@angular/common/http';
+import { AppComponent } from './app/app.component';
+import { errorInterceptor } from './app/core/interceptors/error.interceptor';
+
+bootstrapApplication(AppComponent, {
+  providers: [
+    provideHttpClient(
+      withFetch(),
+      withInterceptors([errorInterceptor])
+    ),
+  ],
+});
+```
+
+## Templates
+
+### Bonnes pratiques
+- Utiliser `@if` / `@for` / `@switch` en priorité.
+- Fournir un `track` dans `@for` pour optimiser le rendu.
+- Importer explicitement les directives/pipes nécessaires (standalone imports).
+- Éviter la logique complexe en template; préférer `computed()`.
+
+## Styles
+
+- CSS à portée de composant par défaut; TailwindCSS optionnel.
+- **Thème** (clair/sombre) via variables CSS et service de thème si nécessaire.
+- Préférer `[class.xxx]` / `[style.xxx]` pour les cas simples; `ngClass`/`ngStyle` pour compositions plus complexes.
+
+## Environnements et configuration
+
+### Stratégies
+Choisir une stratégie et s'y tenir (éviter de mélanger) :
+
+- **Recommandé avec Vite**: fichiers `.env`, `.env.production`, accès via `import.meta.env`. Déclarer les types si besoin.
+- **Alternative sans Vite**: `environment.ts` Angular.
+
+Ne pas exposer de secrets dans le bundle; privilégier les variables d'environnement côté serveur.
+
+## Alias d'import
+
+### `tsconfig.json`
+
+```json
+{
+  "compilerOptions": {
+    "baseUrl": "src",
+    "paths": {
+      "@core/*": ["app/core/*"],
+      "@features/*": ["app/features/*"],
+      "@shared/*": ["app/shared/*"]
+    }
+  }
+}
+```
+
+### `vite.config.ts`
+
+```typescript
+import { defineConfig } from 'vite';
+import angular from '@analogjs/vite-plugin-angular';
+import path from 'node:path';
+
+export default defineConfig({
+  plugins: [angular()],
+  resolve: {
+    alias: {
+      '@core': path.resolve(__dirname, 'src/app/core'),
+      '@features': path.resolve(__dirname, 'src/app/features'),
+      '@shared': path.resolve(__dirname, 'src/app/shared'),
+    },
+  },
+});
+```
+
+## Tests
+
+### Configuration
+- **Vitest** recommandé avec `@analogjs/vitest-angular`.
+- Tester la logique (signaux, services, pipes, guards) et les composants (template + interactions).
+- **Conventions**: `*.spec.ts`, structure AAA (Arrange–Act–Assert).
+- Utiliser des doubles légers (spies) et éviter les tests d'implémentation.
+
+## Qualité de code et CI
+
+### Outils
+- **ESLint** sans erreurs; règles adaptées à Angular moderne (standalone, signals).
+- **Prettier** pour le formatage.
+- Script `typecheck` (`tsc --noEmit`) et pipeline CI minimal: lint + typecheck + test.
+- **Pré-commit**: Husky + lint-staged (lint, prettier:check, typecheck, tests rapides si possible).
+
+### Exemple (extrait) `.husky/pre-commit`
+
+```bash
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+pnpm lint-staged
+```
+
+### `lint-staged.config.json`
+
+```json
+{
+  "*.{ts,tsx,js,jsx}": ["eslint --fix", "prettier --write"],
+  "*.{json,md,css,scss}": ["prettier --write"],
+  "tsconfig*.json": ["tsc --noEmit -p tsconfig.json"]
+}
+```
+
+## Sécurité et accessibilité
+
+### Sécurité
+- **Auth**: privilégier cookies HTTP-only quand pertinent; centraliser gestion des erreurs/redirects.
+- **Sanitize/escape** les contenus non sûrs; `DomSanitizer` avec parcimonie.
+
+### Accessibilité
+- Respecter les attributs **ARIA**, gestion du focus, contraste suffisant.
+
+## Bonnes pratiques supplémentaires
+
+- Éviter les "god services"; favoriser des services orientés domaine (responsabilité unique).
+- **Gestion d'erreurs** utilisateur cohérente (toasts/alerts) via un service partagé.
+- **Logs**: centraliser et filtrer en production.
+- **Documentation** concise (TSDoc) et README d'onboarding.
+
+## Récapitulatif des règles clés
+
+- **Standalone** partout, `standalone: true` explicite.
+- **OnPush** par défaut.
+- `input()` / `output()` et `model()` pour le two-way.
+- `inject()` en services/guards/interceptors; constructor DI autorisé en composants.
+- **Nouveau contrôle de flux** (`@if` / `@for` / `@switch`) et `track` dans `@for`.
+- **Signals**: `set`/`update`; `mutate` seulement si justifié.
+- **Lazy-load**: `loadComponent` pour pages simples; `loadChildren` + `canMatch` pour features complexes.
+- **Suffixes officiels** (`*.component.ts`, `*.service.ts`, …).
+- **Environnements**: Vite (`import.meta.env`) ou environments Angular — ne pas mélanger.
+- **Lint + Prettier + Typecheck** en pré-commit; Vitest pour les tests.

--- a/.postcssrc.json
+++ b/.postcssrc.json
@@ -1,0 +1,5 @@
+{
+  "plugins": {
+    "@tailwindcss/postcss": {}
+  }
+}

--- a/package.json
+++ b/package.json
@@ -29,7 +29,10 @@
     "@angular/forms": "^20.2.0",
     "@angular/platform-browser": "^20.2.0",
     "@angular/router": "^20.2.0",
+    "@tailwindcss/postcss": "^4.1.13",
+    "postcss": "^8.5.6",
     "rxjs": "~7.8.0",
+    "tailwindcss": "^4.1.13",
     "tslib": "^2.3.0",
     "zone.js": "~0.15.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,9 +26,18 @@ importers:
       '@angular/router':
         specifier: ^20.2.0
         version: 20.2.4(@angular/common@20.2.4(@angular/core@20.2.4(@angular/compiler@20.2.4)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.2.4(@angular/compiler@20.2.4)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@20.2.4(@angular/common@20.2.4(@angular/core@20.2.4(@angular/compiler@20.2.4)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.2.4(@angular/compiler@20.2.4)(rxjs@7.8.2)(zone.js@0.15.1)))(rxjs@7.8.2)
+      '@tailwindcss/postcss':
+        specifier: ^4.1.13
+        version: 4.1.13
+      postcss:
+        specifier: ^8.5.6
+        version: 8.5.6
       rxjs:
         specifier: ~7.8.0
         version: 7.8.2
+      tailwindcss:
+        specifier: ^4.1.13
+        version: 4.1.13
       tslib:
         specifier: ^2.3.0
         version: 2.8.1
@@ -38,10 +47,10 @@ importers:
     devDependencies:
       '@analogjs/platform':
         specifier: ^1.20.2
-        version: 1.20.2(@angular/build@20.2.2(@angular/compiler-cli@20.2.4(@angular/compiler@20.2.4)(typescript@5.9.2))(@angular/compiler@20.2.4)(@angular/core@20.2.4(@angular/compiler@20.2.4)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@20.2.4(@angular/common@20.2.4(@angular/core@20.2.4(@angular/compiler@20.2.4)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.2.4(@angular/compiler@20.2.4)(rxjs@7.8.2)(zone.js@0.15.1)))(@types/node@24.3.1)(chokidar@4.0.3)(jiti@2.5.1)(karma@6.4.4)(postcss@8.5.6)(terser@5.44.0)(tslib@2.8.1)(typescript@5.9.2)(vitest@3.2.4))(encoding@0.1.13)(marked-gfm-heading-id@4.1.2(marked@15.0.12))(marked-mangle@1.1.11(marked@15.0.12))(marked@15.0.12)(rolldown@1.0.0-beta.32)(vite@7.1.2(@types/node@24.3.1)(jiti@2.5.1)(sass@1.90.0)(terser@5.44.0))
+        version: 1.20.2(@angular/build@20.2.2(@angular/compiler-cli@20.2.4(@angular/compiler@20.2.4)(typescript@5.9.2))(@angular/compiler@20.2.4)(@angular/core@20.2.4(@angular/compiler@20.2.4)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@20.2.4(@angular/common@20.2.4(@angular/core@20.2.4(@angular/compiler@20.2.4)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.2.4(@angular/compiler@20.2.4)(rxjs@7.8.2)(zone.js@0.15.1)))(@types/node@24.3.1)(chokidar@4.0.3)(jiti@2.5.1)(karma@6.4.4)(lightningcss@1.30.1)(postcss@8.5.6)(tailwindcss@4.1.13)(terser@5.44.0)(tslib@2.8.1)(typescript@5.9.2)(vitest@3.2.4))(encoding@0.1.13)(marked-gfm-heading-id@4.1.2(marked@15.0.12))(marked-mangle@1.1.11(marked@15.0.12))(marked@15.0.12)(rolldown@1.0.0-beta.32)(vite@7.1.2(@types/node@24.3.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.90.0)(terser@5.44.0))
       '@analogjs/vite-plugin-angular':
         specifier: ^1.20.2
-        version: 1.20.2(@angular/build@20.2.2(@angular/compiler-cli@20.2.4(@angular/compiler@20.2.4)(typescript@5.9.2))(@angular/compiler@20.2.4)(@angular/core@20.2.4(@angular/compiler@20.2.4)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@20.2.4(@angular/common@20.2.4(@angular/core@20.2.4(@angular/compiler@20.2.4)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.2.4(@angular/compiler@20.2.4)(rxjs@7.8.2)(zone.js@0.15.1)))(@types/node@24.3.1)(chokidar@4.0.3)(jiti@2.5.1)(karma@6.4.4)(postcss@8.5.6)(terser@5.44.0)(tslib@2.8.1)(typescript@5.9.2)(vitest@3.2.4))
+        version: 1.20.2(@angular/build@20.2.2(@angular/compiler-cli@20.2.4(@angular/compiler@20.2.4)(typescript@5.9.2))(@angular/compiler@20.2.4)(@angular/core@20.2.4(@angular/compiler@20.2.4)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@20.2.4(@angular/common@20.2.4(@angular/core@20.2.4(@angular/compiler@20.2.4)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.2.4(@angular/compiler@20.2.4)(rxjs@7.8.2)(zone.js@0.15.1)))(@types/node@24.3.1)(chokidar@4.0.3)(jiti@2.5.1)(karma@6.4.4)(lightningcss@1.30.1)(postcss@8.5.6)(tailwindcss@4.1.13)(terser@5.44.0)(tslib@2.8.1)(typescript@5.9.2)(vitest@3.2.4))
       '@angular-eslint/builder':
         specifier: ^20.2.0
         version: 20.2.0(chokidar@4.0.3)(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2)
@@ -59,7 +68,7 @@ importers:
         version: 20.2.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2)
       '@angular/build':
         specifier: ^20.2.2
-        version: 20.2.2(@angular/compiler-cli@20.2.4(@angular/compiler@20.2.4)(typescript@5.9.2))(@angular/compiler@20.2.4)(@angular/core@20.2.4(@angular/compiler@20.2.4)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@20.2.4(@angular/common@20.2.4(@angular/core@20.2.4(@angular/compiler@20.2.4)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.2.4(@angular/compiler@20.2.4)(rxjs@7.8.2)(zone.js@0.15.1)))(@types/node@24.3.1)(chokidar@4.0.3)(jiti@2.5.1)(karma@6.4.4)(postcss@8.5.6)(terser@5.44.0)(tslib@2.8.1)(typescript@5.9.2)(vitest@3.2.4)
+        version: 20.2.2(@angular/compiler-cli@20.2.4(@angular/compiler@20.2.4)(typescript@5.9.2))(@angular/compiler@20.2.4)(@angular/core@20.2.4(@angular/compiler@20.2.4)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@20.2.4(@angular/common@20.2.4(@angular/core@20.2.4(@angular/compiler@20.2.4)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.2.4(@angular/compiler@20.2.4)(rxjs@7.8.2)(zone.js@0.15.1)))(@types/node@24.3.1)(chokidar@4.0.3)(jiti@2.5.1)(karma@6.4.4)(lightningcss@1.30.1)(postcss@8.5.6)(tailwindcss@4.1.13)(terser@5.44.0)(tslib@2.8.1)(typescript@5.9.2)(vitest@3.2.4)
       '@angular/cli':
         specifier: ^20.2.2
         version: 20.2.2(@types/node@24.3.1)(chokidar@4.0.3)
@@ -113,7 +122,7 @@ importers:
         version: 5.9.2
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@24.3.1)(@vitest/ui@3.2.4)(jiti@2.5.1)(jsdom@26.1.0)(sass@1.90.0)(terser@5.44.0)
+        version: 3.2.4(@types/node@24.3.1)(@vitest/ui@3.2.4)(jiti@2.5.1)(jsdom@26.1.0)(lightningcss@1.30.1)(sass@1.90.0)(terser@5.44.0)
 
 packages:
 
@@ -172,6 +181,10 @@ packages:
   '@algolia/requester-node-http@5.35.0':
     resolution: {integrity: sha512-RgLX78ojYOrThJHrIiPzT4HW3yfQa0D7K+MQ81rhxqaNyNBu4F1r+72LNHYH/Z+y9I1Mrjrd/c/Ue5zfDgAEjQ==}
     engines: {node: '>= 14.0.0'}
+
+  '@alloc/quick-lru@5.2.0':
+    resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
+    engines: {node: '>=10'}
 
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
@@ -1574,6 +1587,94 @@ packages:
   '@speed-highlight/core@1.2.7':
     resolution: {integrity: sha512-0dxmVj4gxg3Jg879kvFS/msl4s9F3T9UXC1InxgOf7t5NvcPD97u/WTA5vL/IxWHMn7qSxBozqrnnE2wvl1m8g==}
 
+  '@tailwindcss/node@4.1.13':
+    resolution: {integrity: sha512-eq3ouolC1oEFOAvOMOBAmfCIqZBJuvWvvYWh5h5iOYfe1HFC6+GZ6EIL0JdM3/niGRJmnrOc+8gl9/HGUaaptw==}
+
+  '@tailwindcss/oxide-android-arm64@4.1.13':
+    resolution: {integrity: sha512-BrpTrVYyejbgGo57yc8ieE+D6VT9GOgnNdmh5Sac6+t0m+v+sKQevpFVpwX3pBrM2qKrQwJ0c5eDbtjouY/+ew==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [android]
+
+  '@tailwindcss/oxide-darwin-arm64@4.1.13':
+    resolution: {integrity: sha512-YP+Jksc4U0KHcu76UhRDHq9bx4qtBftp9ShK/7UGfq0wpaP96YVnnjFnj3ZFrUAjc5iECzODl/Ts0AN7ZPOANQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-darwin-x64@4.1.13':
+    resolution: {integrity: sha512-aAJ3bbwrn/PQHDxCto9sxwQfT30PzyYJFG0u/BWZGeVXi5Hx6uuUOQEI2Fa43qvmUjTRQNZnGqe9t0Zntexeuw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-freebsd-x64@4.1.13':
+    resolution: {integrity: sha512-Wt8KvASHwSXhKE/dJLCCWcTSVmBj3xhVhp/aF3RpAhGeZ3sVo7+NTfgiN8Vey/Fi8prRClDs6/f0KXPDTZE6nQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.1.13':
+    resolution: {integrity: sha512-mbVbcAsW3Gkm2MGwA93eLtWrwajz91aXZCNSkGTx/R5eb6KpKD5q8Ueckkh9YNboU8RH7jiv+ol/I7ZyQ9H7Bw==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.1.13':
+    resolution: {integrity: sha512-wdtfkmpXiwej/yoAkrCP2DNzRXCALq9NVLgLELgLim1QpSfhQM5+ZxQQF8fkOiEpuNoKLp4nKZ6RC4kmeFH0HQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.1.13':
+    resolution: {integrity: sha512-hZQrmtLdhyqzXHB7mkXfq0IYbxegaqTmfa1p9MBj72WPoDD3oNOh1Lnxf6xZLY9C3OV6qiCYkO1i/LrzEdW2mg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.1.13':
+    resolution: {integrity: sha512-uaZTYWxSXyMWDJZNY1Ul7XkJTCBRFZ5Fo6wtjrgBKzZLoJNrG+WderJwAjPzuNZOnmdrVg260DKwXCFtJ/hWRQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-x64-musl@4.1.13':
+    resolution: {integrity: sha512-oXiPj5mi4Hdn50v5RdnuuIms0PVPI/EG4fxAfFiIKQh5TgQgX7oSuDWntHW7WNIi/yVLAiS+CRGW4RkoGSSgVQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@tailwindcss/oxide-wasm32-wasi@4.1.13':
+    resolution: {integrity: sha512-+LC2nNtPovtrDwBc/nqnIKYh/W2+R69FA0hgoeOn64BdCX522u19ryLh3Vf3F8W49XBcMIxSe665kwy21FkhvA==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+    bundledDependencies:
+      - '@napi-rs/wasm-runtime'
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@tybys/wasm-util'
+      - '@emnapi/wasi-threads'
+      - tslib
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.1.13':
+    resolution: {integrity: sha512-dziTNeQXtoQ2KBXmrjCxsuPk3F3CQ/yb7ZNZNA+UkNTeiTGgfeh+gH5Pi7mRncVgcPD2xgHvkFCh/MhZWSgyQg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.1.13':
+    resolution: {integrity: sha512-3+LKesjXydTkHk5zXX01b5KMzLV1xl2mcktBJkje7rhFUpUlYJy7IMOLqjIRQncLTa1WZZiFY/foAeB5nmaiTw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@tailwindcss/oxide@4.1.13':
+    resolution: {integrity: sha512-CPgsM1IpGRa880sMbYmG1s4xhAy3xEt1QULgTJGQmZUeNgXFR7s1YxYygmJyBGtou4SyEosGAGEeYqY7R53bIA==}
+    engines: {node: '>= 10'}
+
+  '@tailwindcss/postcss@4.1.13':
+    resolution: {integrity: sha512-HLgx6YSFKJT7rJqh9oJs/TkBFhxuMOfUKSBEPYwV+t78POOBsdQ7crhZLzwcH3T0UyUuOzU/GK5pk5eKr3wCiQ==}
+
   '@testing-library/angular@18.0.0':
     resolution: {integrity: sha512-0seNMa4ql2I3VD7CtnI9i4sFgxEgRES+EtGid8H4MTuOK/dlj457mVk8tWdFjPQPC/cPromcUNw0is1ogO3DSA==}
     peerDependencies:
@@ -2329,6 +2430,10 @@ packages:
     resolution: {integrity: sha512-ZCkIjSYNDyGn0R6ewHDtXgns/Zre/NT6Agvq1/WobF7JXgFff4SeDroKiCO3fNJreU9YG429Sc81o4w5ok/W5g==}
     engines: {node: '>=10.2.0'}
 
+  enhanced-resolve@5.18.3:
+    resolution: {integrity: sha512-d4lC8xfavMeBjzGr2vECC3fsGXziXZQyJxD868h2M/mBI3PwAuODxAkLkq5HYuvrPYcUtiLzsTo8U3PgX3Ocww==}
+    engines: {node: '>=10.13.0'}
+
   ent@2.2.2:
     resolution: {integrity: sha512-kKvD1tO6BM+oK9HzCPpUdRb4vKFQY/FPTFmurMvh6LlN68VMrdj77w8yp51/kDbpkFOS9J8w5W6zIzgM2H8/hw==}
     engines: {node: '>= 0.4'}
@@ -3049,6 +3154,70 @@ packages:
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
+
+  lightningcss-darwin-arm64@1.30.1:
+    resolution: {integrity: sha512-c8JK7hyE65X1MHMN+Viq9n11RRC7hgin3HhYKhrMyaXflk5GVplZ60IxyoVtzILeKr+xAJwg6zK6sjTBJ0FKYQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.30.1:
+    resolution: {integrity: sha512-k1EvjakfumAQoTfcXUcHQZhSpLlkAuEkdMBsI/ivWw9hL+7FtilQc0Cy3hrx0AAQrVtQAbMI7YjCgYgvn37PzA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.30.1:
+    resolution: {integrity: sha512-kmW6UGCGg2PcyUE59K5r0kWfKPAVy4SltVeut+umLCFoJ53RdCUWxcRDzO1eTaxf/7Q2H7LTquFHPL5R+Gjyig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.30.1:
+    resolution: {integrity: sha512-MjxUShl1v8pit+6D/zSPq9S9dQ2NPFSQwGvxBCYaBYLPlCWuPh9/t1MRS8iUaR8i+a6w7aps+B4N0S1TYP/R+Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.30.1:
+    resolution: {integrity: sha512-gB72maP8rmrKsnKYy8XUuXi/4OctJiuQjcuqWNlJQ6jZiWqtPvqFziskH3hnajfvKB27ynbVCucKSm2rkQp4Bw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-arm64-musl@1.30.1:
+    resolution: {integrity: sha512-jmUQVx4331m6LIX+0wUhBbmMX7TCfjF5FoOH6SD1CttzuYlGNVpA7QnrmLxrsub43ClTINfGSYyHe2HWeLl5CQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-x64-gnu@1.30.1:
+    resolution: {integrity: sha512-piWx3z4wN8J8z3+O5kO74+yr6ze/dKmPnI7vLqfSqI8bccaTGY5xiSGVIJBDd5K5BHlvVLpUB3S2YCfelyJ1bw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-linux-x64-musl@1.30.1:
+    resolution: {integrity: sha512-rRomAK7eIkL+tHY0YPxbc5Dra2gXlI63HL+v1Pdi1a3sC+tJTcFrHX+E86sulgAXeI7rSzDYhPSeHHjqFhqfeQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-win32-arm64-msvc@1.30.1:
+    resolution: {integrity: sha512-mSL4rqPi4iXq5YVqzSsJgMVFENoa4nGTT/GjO2c0Yl9OuQfPsIfncvLrEW6RbbB24WtZ3xP/2CCmI3tNkNV4oA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.30.1:
+    resolution: {integrity: sha512-PVqXh48wh4T53F/1CCu8PIPCxLzWyCnn/9T5W1Jpmdy5h9Cwd+0YQS6/LwhHXSafuc61/xg9Lv5OrCby6a++jg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.30.1:
+    resolution: {integrity: sha512-xi6IyHML+c9+Q3W0S4fCQJOym42pyurFiJUHEcEyHS0CeKzia4yZDEsLlqOFykxOdHpNy0NmvVO31vcSqAxJCg==}
+    engines: {node: '>= 12.0.0'}
 
   listhen@1.9.0:
     resolution: {integrity: sha512-I8oW2+QL5KJo8zXNWX046M134WchxsXC7SawLPvRQpogCbkyQIaFxPE89A2HiwR7vAK2Dm2ERBAmyjTYGYEpBg==}
@@ -4044,6 +4213,13 @@ packages:
     resolution: {integrity: sha512-ulAk51I9UVUyJgxlv9M6lFot2WP3e7t8Kz9+IS6D4rVba1tR9kON+Ey69f+1R4Q8cd45Lod6a4IcJIxnzGc/zA==}
     engines: {node: '>=18'}
 
+  tailwindcss@4.1.13:
+    resolution: {integrity: sha512-i+zidfmTqtwquj4hMEwdjshYYgMbOrPzb9a0M3ZgNa0JMoZeFC6bxZvO8yr8ozS6ix2SDz0+mvryPeBs2TFE+w==}
+
+  tapable@2.2.3:
+    resolution: {integrity: sha512-ZL6DDuAlRlLGghwcfmSn9sK3Hr6ArtyudlSAiCqQ6IfE+b+HHbydbYDIG15IfS5do+7XQQBdBiubF/cV2dnDzg==}
+    engines: {node: '>=6'}
+
   tar-stream@3.1.7:
     resolution: {integrity: sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==}
 
@@ -4681,21 +4857,23 @@ snapshots:
     dependencies:
       '@algolia/client-common': 5.35.0
 
+  '@alloc/quick-lru@5.2.0': {}
+
   '@ampproject/remapping@2.3.0':
     dependencies:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.30
 
-  '@analogjs/platform@1.20.2(@angular/build@20.2.2(@angular/compiler-cli@20.2.4(@angular/compiler@20.2.4)(typescript@5.9.2))(@angular/compiler@20.2.4)(@angular/core@20.2.4(@angular/compiler@20.2.4)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@20.2.4(@angular/common@20.2.4(@angular/core@20.2.4(@angular/compiler@20.2.4)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.2.4(@angular/compiler@20.2.4)(rxjs@7.8.2)(zone.js@0.15.1)))(@types/node@24.3.1)(chokidar@4.0.3)(jiti@2.5.1)(karma@6.4.4)(postcss@8.5.6)(terser@5.44.0)(tslib@2.8.1)(typescript@5.9.2)(vitest@3.2.4))(encoding@0.1.13)(marked-gfm-heading-id@4.1.2(marked@15.0.12))(marked-mangle@1.1.11(marked@15.0.12))(marked@15.0.12)(rolldown@1.0.0-beta.32)(vite@7.1.2(@types/node@24.3.1)(jiti@2.5.1)(sass@1.90.0)(terser@5.44.0))':
+  '@analogjs/platform@1.20.2(@angular/build@20.2.2(@angular/compiler-cli@20.2.4(@angular/compiler@20.2.4)(typescript@5.9.2))(@angular/compiler@20.2.4)(@angular/core@20.2.4(@angular/compiler@20.2.4)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@20.2.4(@angular/common@20.2.4(@angular/core@20.2.4(@angular/compiler@20.2.4)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.2.4(@angular/compiler@20.2.4)(rxjs@7.8.2)(zone.js@0.15.1)))(@types/node@24.3.1)(chokidar@4.0.3)(jiti@2.5.1)(karma@6.4.4)(lightningcss@1.30.1)(postcss@8.5.6)(tailwindcss@4.1.13)(terser@5.44.0)(tslib@2.8.1)(typescript@5.9.2)(vitest@3.2.4))(encoding@0.1.13)(marked-gfm-heading-id@4.1.2(marked@15.0.12))(marked-mangle@1.1.11(marked@15.0.12))(marked@15.0.12)(rolldown@1.0.0-beta.32)(vite@7.1.2(@types/node@24.3.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.90.0)(terser@5.44.0))':
     dependencies:
-      '@analogjs/vite-plugin-angular': 1.20.2(@angular/build@20.2.2(@angular/compiler-cli@20.2.4(@angular/compiler@20.2.4)(typescript@5.9.2))(@angular/compiler@20.2.4)(@angular/core@20.2.4(@angular/compiler@20.2.4)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@20.2.4(@angular/common@20.2.4(@angular/core@20.2.4(@angular/compiler@20.2.4)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.2.4(@angular/compiler@20.2.4)(rxjs@7.8.2)(zone.js@0.15.1)))(@types/node@24.3.1)(chokidar@4.0.3)(jiti@2.5.1)(karma@6.4.4)(postcss@8.5.6)(terser@5.44.0)(tslib@2.8.1)(typescript@5.9.2)(vitest@3.2.4))
+      '@analogjs/vite-plugin-angular': 1.20.2(@angular/build@20.2.2(@angular/compiler-cli@20.2.4(@angular/compiler@20.2.4)(typescript@5.9.2))(@angular/compiler@20.2.4)(@angular/core@20.2.4(@angular/compiler@20.2.4)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@20.2.4(@angular/common@20.2.4(@angular/core@20.2.4(@angular/compiler@20.2.4)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.2.4(@angular/compiler@20.2.4)(rxjs@7.8.2)(zone.js@0.15.1)))(@types/node@24.3.1)(chokidar@4.0.3)(jiti@2.5.1)(karma@6.4.4)(lightningcss@1.30.1)(postcss@8.5.6)(tailwindcss@4.1.13)(terser@5.44.0)(tslib@2.8.1)(typescript@5.9.2)(vitest@3.2.4))
       '@analogjs/vite-plugin-nitro': 1.20.2(encoding@0.1.13)(rolldown@1.0.0-beta.32)
       marked: 15.0.12
       marked-gfm-heading-id: 4.1.2(marked@15.0.12)
       marked-mangle: 1.1.11(marked@15.0.12)
       nitropack: 2.12.5(encoding@0.1.13)(rolldown@1.0.0-beta.32)
-      vite: 7.1.2(@types/node@24.3.1)(jiti@2.5.1)(sass@1.90.0)(terser@5.44.0)
-      vitefu: 1.1.1(vite@7.1.2(@types/node@24.3.1)(jiti@2.5.1)(sass@1.90.0)(terser@5.44.0))
+      vite: 7.1.2(@types/node@24.3.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.90.0)(terser@5.44.0)
+      vitefu: 1.1.1(vite@7.1.2(@types/node@24.3.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.90.0)(terser@5.44.0))
     transitivePeerDependencies:
       - '@angular-devkit/build-angular'
       - '@angular/build'
@@ -4727,12 +4905,12 @@ snapshots:
       - uploadthing
       - xml2js
 
-  '@analogjs/vite-plugin-angular@1.20.2(@angular/build@20.2.2(@angular/compiler-cli@20.2.4(@angular/compiler@20.2.4)(typescript@5.9.2))(@angular/compiler@20.2.4)(@angular/core@20.2.4(@angular/compiler@20.2.4)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@20.2.4(@angular/common@20.2.4(@angular/core@20.2.4(@angular/compiler@20.2.4)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.2.4(@angular/compiler@20.2.4)(rxjs@7.8.2)(zone.js@0.15.1)))(@types/node@24.3.1)(chokidar@4.0.3)(jiti@2.5.1)(karma@6.4.4)(postcss@8.5.6)(terser@5.44.0)(tslib@2.8.1)(typescript@5.9.2)(vitest@3.2.4))':
+  '@analogjs/vite-plugin-angular@1.20.2(@angular/build@20.2.2(@angular/compiler-cli@20.2.4(@angular/compiler@20.2.4)(typescript@5.9.2))(@angular/compiler@20.2.4)(@angular/core@20.2.4(@angular/compiler@20.2.4)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@20.2.4(@angular/common@20.2.4(@angular/core@20.2.4(@angular/compiler@20.2.4)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.2.4(@angular/compiler@20.2.4)(rxjs@7.8.2)(zone.js@0.15.1)))(@types/node@24.3.1)(chokidar@4.0.3)(jiti@2.5.1)(karma@6.4.4)(lightningcss@1.30.1)(postcss@8.5.6)(tailwindcss@4.1.13)(terser@5.44.0)(tslib@2.8.1)(typescript@5.9.2)(vitest@3.2.4))':
     dependencies:
       ts-morph: 21.0.1
       vfile: 6.0.3
     optionalDependencies:
-      '@angular/build': 20.2.2(@angular/compiler-cli@20.2.4(@angular/compiler@20.2.4)(typescript@5.9.2))(@angular/compiler@20.2.4)(@angular/core@20.2.4(@angular/compiler@20.2.4)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@20.2.4(@angular/common@20.2.4(@angular/core@20.2.4(@angular/compiler@20.2.4)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.2.4(@angular/compiler@20.2.4)(rxjs@7.8.2)(zone.js@0.15.1)))(@types/node@24.3.1)(chokidar@4.0.3)(jiti@2.5.1)(karma@6.4.4)(postcss@8.5.6)(terser@5.44.0)(tslib@2.8.1)(typescript@5.9.2)(vitest@3.2.4)
+      '@angular/build': 20.2.2(@angular/compiler-cli@20.2.4(@angular/compiler@20.2.4)(typescript@5.9.2))(@angular/compiler@20.2.4)(@angular/core@20.2.4(@angular/compiler@20.2.4)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@20.2.4(@angular/common@20.2.4(@angular/core@20.2.4(@angular/compiler@20.2.4)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.2.4(@angular/compiler@20.2.4)(rxjs@7.8.2)(zone.js@0.15.1)))(@types/node@24.3.1)(chokidar@4.0.3)(jiti@2.5.1)(karma@6.4.4)(lightningcss@1.30.1)(postcss@8.5.6)(tailwindcss@4.1.13)(terser@5.44.0)(tslib@2.8.1)(typescript@5.9.2)(vitest@3.2.4)
 
   '@analogjs/vite-plugin-nitro@1.20.2(encoding@0.1.13)(rolldown@1.0.0-beta.32)':
     dependencies:
@@ -4861,7 +5039,7 @@ snapshots:
       eslint: 9.35.0(jiti@2.5.1)
       typescript: 5.9.2
 
-  '@angular/build@20.2.2(@angular/compiler-cli@20.2.4(@angular/compiler@20.2.4)(typescript@5.9.2))(@angular/compiler@20.2.4)(@angular/core@20.2.4(@angular/compiler@20.2.4)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@20.2.4(@angular/common@20.2.4(@angular/core@20.2.4(@angular/compiler@20.2.4)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.2.4(@angular/compiler@20.2.4)(rxjs@7.8.2)(zone.js@0.15.1)))(@types/node@24.3.1)(chokidar@4.0.3)(jiti@2.5.1)(karma@6.4.4)(postcss@8.5.6)(terser@5.44.0)(tslib@2.8.1)(typescript@5.9.2)(vitest@3.2.4)':
+  '@angular/build@20.2.2(@angular/compiler-cli@20.2.4(@angular/compiler@20.2.4)(typescript@5.9.2))(@angular/compiler@20.2.4)(@angular/core@20.2.4(@angular/compiler@20.2.4)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@20.2.4(@angular/common@20.2.4(@angular/core@20.2.4(@angular/compiler@20.2.4)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.2.4(@angular/compiler@20.2.4)(rxjs@7.8.2)(zone.js@0.15.1)))(@types/node@24.3.1)(chokidar@4.0.3)(jiti@2.5.1)(karma@6.4.4)(lightningcss@1.30.1)(postcss@8.5.6)(tailwindcss@4.1.13)(terser@5.44.0)(tslib@2.8.1)(typescript@5.9.2)(vitest@3.2.4)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.2002.2(chokidar@4.0.3)
@@ -4871,7 +5049,7 @@ snapshots:
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-split-export-declaration': 7.24.7
       '@inquirer/confirm': 5.1.14(@types/node@24.3.1)
-      '@vitejs/plugin-basic-ssl': 2.1.0(vite@7.1.2(@types/node@24.3.1)(jiti@2.5.1)(sass@1.90.0)(terser@5.44.0))
+      '@vitejs/plugin-basic-ssl': 2.1.0(vite@7.1.2(@types/node@24.3.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.90.0)(terser@5.44.0))
       beasties: 0.3.5
       browserslist: 4.25.4
       esbuild: 0.25.9
@@ -4891,7 +5069,7 @@ snapshots:
       tinyglobby: 0.2.14
       tslib: 2.8.1
       typescript: 5.9.2
-      vite: 7.1.2(@types/node@24.3.1)(jiti@2.5.1)(sass@1.90.0)(terser@5.44.0)
+      vite: 7.1.2(@types/node@24.3.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.90.0)(terser@5.44.0)
       watchpack: 2.4.4
     optionalDependencies:
       '@angular/core': 20.2.4(@angular/compiler@20.2.4)(rxjs@7.8.2)(zone.js@0.15.1)
@@ -4899,7 +5077,8 @@ snapshots:
       karma: 6.4.4
       lmdb: 3.4.2
       postcss: 8.5.6
-      vitest: 3.2.4(@types/node@24.3.1)(@vitest/ui@3.2.4)(jiti@2.5.1)(jsdom@26.1.0)(sass@1.90.0)(terser@5.44.0)
+      tailwindcss: 4.1.13
+      vitest: 3.2.4(@types/node@24.3.1)(@vitest/ui@3.2.4)(jiti@2.5.1)(jsdom@26.1.0)(lightningcss@1.30.1)(sass@1.90.0)(terser@5.44.0)
     transitivePeerDependencies:
       - '@types/node'
       - chokidar
@@ -6019,6 +6198,78 @@ snapshots:
 
   '@speed-highlight/core@1.2.7': {}
 
+  '@tailwindcss/node@4.1.13':
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      enhanced-resolve: 5.18.3
+      jiti: 2.5.1
+      lightningcss: 1.30.1
+      magic-string: 0.30.19
+      source-map-js: 1.2.1
+      tailwindcss: 4.1.13
+
+  '@tailwindcss/oxide-android-arm64@4.1.13':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-arm64@4.1.13':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-x64@4.1.13':
+    optional: true
+
+  '@tailwindcss/oxide-freebsd-x64@4.1.13':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.1.13':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.1.13':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.1.13':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.1.13':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-musl@4.1.13':
+    optional: true
+
+  '@tailwindcss/oxide-wasm32-wasi@4.1.13':
+    optional: true
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.1.13':
+    optional: true
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.1.13':
+    optional: true
+
+  '@tailwindcss/oxide@4.1.13':
+    dependencies:
+      detect-libc: 2.0.4
+      tar: 7.4.3
+    optionalDependencies:
+      '@tailwindcss/oxide-android-arm64': 4.1.13
+      '@tailwindcss/oxide-darwin-arm64': 4.1.13
+      '@tailwindcss/oxide-darwin-x64': 4.1.13
+      '@tailwindcss/oxide-freebsd-x64': 4.1.13
+      '@tailwindcss/oxide-linux-arm-gnueabihf': 4.1.13
+      '@tailwindcss/oxide-linux-arm64-gnu': 4.1.13
+      '@tailwindcss/oxide-linux-arm64-musl': 4.1.13
+      '@tailwindcss/oxide-linux-x64-gnu': 4.1.13
+      '@tailwindcss/oxide-linux-x64-musl': 4.1.13
+      '@tailwindcss/oxide-wasm32-wasi': 4.1.13
+      '@tailwindcss/oxide-win32-arm64-msvc': 4.1.13
+      '@tailwindcss/oxide-win32-x64-msvc': 4.1.13
+
+  '@tailwindcss/postcss@4.1.13':
+    dependencies:
+      '@alloc/quick-lru': 5.2.0
+      '@tailwindcss/node': 4.1.13
+      '@tailwindcss/oxide': 4.1.13
+      postcss: 8.5.6
+      tailwindcss: 4.1.13
+
   '@testing-library/angular@18.0.0(@angular/common@20.2.4(@angular/core@20.2.4(@angular/compiler@20.2.4)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.2.4(@angular/compiler@20.2.4)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@20.2.4(@angular/common@20.2.4(@angular/core@20.2.4(@angular/compiler@20.2.4)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.2.4(@angular/compiler@20.2.4)(rxjs@7.8.2)(zone.js@0.15.1)))(@angular/router@20.2.4(@angular/common@20.2.4(@angular/core@20.2.4(@angular/compiler@20.2.4)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.2.4(@angular/compiler@20.2.4)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@20.2.4(@angular/common@20.2.4(@angular/core@20.2.4(@angular/compiler@20.2.4)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.2.4(@angular/compiler@20.2.4)(rxjs@7.8.2)(zone.js@0.15.1)))(rxjs@7.8.2))(@testing-library/dom@10.4.1)':
     dependencies:
       '@angular/common': 20.2.4(@angular/core@20.2.4(@angular/compiler@20.2.4)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2)
@@ -6198,9 +6449,9 @@ snapshots:
       - rollup
       - supports-color
 
-  '@vitejs/plugin-basic-ssl@2.1.0(vite@7.1.2(@types/node@24.3.1)(jiti@2.5.1)(sass@1.90.0)(terser@5.44.0))':
+  '@vitejs/plugin-basic-ssl@2.1.0(vite@7.1.2(@types/node@24.3.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.90.0)(terser@5.44.0))':
     dependencies:
-      vite: 7.1.2(@types/node@24.3.1)(jiti@2.5.1)(sass@1.90.0)(terser@5.44.0)
+      vite: 7.1.2(@types/node@24.3.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.90.0)(terser@5.44.0)
 
   '@vitest/expect@3.2.4':
     dependencies:
@@ -6210,13 +6461,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@7.1.2(@types/node@24.3.1)(jiti@2.5.1)(sass@1.90.0)(terser@5.44.0))':
+  '@vitest/mocker@3.2.4(vite@7.1.2(@types/node@24.3.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.90.0)(terser@5.44.0))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.19
     optionalDependencies:
-      vite: 7.1.2(@types/node@24.3.1)(jiti@2.5.1)(sass@1.90.0)(terser@5.44.0)
+      vite: 7.1.2(@types/node@24.3.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.90.0)(terser@5.44.0)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -6247,7 +6498,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.14
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/node@24.3.1)(@vitest/ui@3.2.4)(jiti@2.5.1)(jsdom@26.1.0)(sass@1.90.0)(terser@5.44.0)
+      vitest: 3.2.4(@types/node@24.3.1)(@vitest/ui@3.2.4)(jiti@2.5.1)(jsdom@26.1.0)(lightningcss@1.30.1)(sass@1.90.0)(terser@5.44.0)
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -6858,6 +7109,11 @@ snapshots:
       - supports-color
       - utf-8-validate
     optional: true
+
+  enhanced-resolve@5.18.3:
+    dependencies:
+      graceful-fs: 4.2.11
+      tapable: 2.2.3
 
   ent@2.2.2:
     dependencies:
@@ -7657,6 +7913,51 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
+
+  lightningcss-darwin-arm64@1.30.1:
+    optional: true
+
+  lightningcss-darwin-x64@1.30.1:
+    optional: true
+
+  lightningcss-freebsd-x64@1.30.1:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.30.1:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.30.1:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.30.1:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.30.1:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.30.1:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.30.1:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.30.1:
+    optional: true
+
+  lightningcss@1.30.1:
+    dependencies:
+      detect-libc: 2.0.4
+    optionalDependencies:
+      lightningcss-darwin-arm64: 1.30.1
+      lightningcss-darwin-x64: 1.30.1
+      lightningcss-freebsd-x64: 1.30.1
+      lightningcss-linux-arm-gnueabihf: 1.30.1
+      lightningcss-linux-arm64-gnu: 1.30.1
+      lightningcss-linux-arm64-musl: 1.30.1
+      lightningcss-linux-x64-gnu: 1.30.1
+      lightningcss-linux-x64-musl: 1.30.1
+      lightningcss-win32-arm64-msvc: 1.30.1
+      lightningcss-win32-x64-msvc: 1.30.1
 
   listhen@1.9.0:
     dependencies:
@@ -8887,6 +9188,10 @@ snapshots:
 
   system-architecture@0.1.0: {}
 
+  tailwindcss@4.1.13: {}
+
+  tapable@2.2.3: {}
+
   tar-stream@3.1.7:
     dependencies:
       b4a: 1.6.7
@@ -9160,13 +9465,13 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite-node@3.2.4(@types/node@24.3.1)(jiti@2.5.1)(sass@1.90.0)(terser@5.44.0):
+  vite-node@3.2.4(@types/node@24.3.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.90.0)(terser@5.44.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.1
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.1.2(@types/node@24.3.1)(jiti@2.5.1)(sass@1.90.0)(terser@5.44.0)
+      vite: 7.1.2(@types/node@24.3.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.90.0)(terser@5.44.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -9181,7 +9486,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@7.1.2(@types/node@24.3.1)(jiti@2.5.1)(sass@1.90.0)(terser@5.44.0):
+  vite@7.1.2(@types/node@24.3.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.90.0)(terser@5.44.0):
     dependencies:
       esbuild: 0.25.9
       fdir: 6.5.0(picomatch@4.0.3)
@@ -9193,18 +9498,19 @@ snapshots:
       '@types/node': 24.3.1
       fsevents: 2.3.3
       jiti: 2.5.1
+      lightningcss: 1.30.1
       sass: 1.90.0
       terser: 5.44.0
 
-  vitefu@1.1.1(vite@7.1.2(@types/node@24.3.1)(jiti@2.5.1)(sass@1.90.0)(terser@5.44.0)):
+  vitefu@1.1.1(vite@7.1.2(@types/node@24.3.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.90.0)(terser@5.44.0)):
     optionalDependencies:
-      vite: 7.1.2(@types/node@24.3.1)(jiti@2.5.1)(sass@1.90.0)(terser@5.44.0)
+      vite: 7.1.2(@types/node@24.3.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.90.0)(terser@5.44.0)
 
-  vitest@3.2.4(@types/node@24.3.1)(@vitest/ui@3.2.4)(jiti@2.5.1)(jsdom@26.1.0)(sass@1.90.0)(terser@5.44.0):
+  vitest@3.2.4(@types/node@24.3.1)(@vitest/ui@3.2.4)(jiti@2.5.1)(jsdom@26.1.0)(lightningcss@1.30.1)(sass@1.90.0)(terser@5.44.0):
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.1.2(@types/node@24.3.1)(jiti@2.5.1)(sass@1.90.0)(terser@5.44.0))
+      '@vitest/mocker': 3.2.4(vite@7.1.2(@types/node@24.3.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.90.0)(terser@5.44.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -9222,8 +9528,8 @@ snapshots:
       tinyglobby: 0.2.14
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.1.2(@types/node@24.3.1)(jiti@2.5.1)(sass@1.90.0)(terser@5.44.0)
-      vite-node: 3.2.4(@types/node@24.3.1)(jiti@2.5.1)(sass@1.90.0)(terser@5.44.0)
+      vite: 7.1.2(@types/node@24.3.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.90.0)(terser@5.44.0)
+      vite-node: 3.2.4(@types/node@24.3.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.90.0)(terser@5.44.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.3.1

--- a/src/index.html
+++ b/src/index.html
@@ -5,7 +5,7 @@
   <title>NgCandidashApp</title>
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="icon" type="image/x-icon" href="favicon.ico">
+  <link rel="icon" type="image/x-icon" href="/favicon.ico">
 </head>
 <body>
   <app-root></app-root>

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,1 +1,9 @@
-/* You can add global styles to this file, and also import other style files */
+@import "tailwindcss";
+
+@theme {
+  --text: oklch(94.16% 0.011 123.46);
+  --background: oklch(17.53% 0.020 121.92);
+  --primary: oklch(87.73% 0.105 121.80);
+  --secondary: oklch(61.19% 0.151 126.53);
+  --accent: oklch(91.52% 0.225 126.25);
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,25 @@
     "experimentalDecorators": true,
     "importHelpers": true,
     "target": "ES2022",
-    "module": "preserve"
+    "module": "preserve",
+    "baseUrl": "./src",
+    "paths": {
+      "@app/*": [
+        "app/*"
+      ],
+      "@environments/*": [
+        "environments/*"
+      ],
+      "@shared/*": [
+        "app/shared/*"
+      ],
+      "@core/*": [
+        "app/core/*"
+      ],
+      "@features/*": [
+        "app/features/*"
+      ]
+    }
   },
   "angularCompilerOptions": {
     "enableI18nLegacyMessageIdFormat": false,


### PR DESCRIPTION
- Ajoute @tailwindcss/postcss, postcss, et tailwindcss comme dépendances
- Configure PostCSS via un fichier .postcssrc.json
- Met à jour styles.css pour inclure l'import TailwindCSS et définir des variables de thème
- Ajuste tsconfig.json avec des alias pour une meilleure organisation du code