### PR TITLE
feat(auth): implémente des guards et améliore la gestion des tokens JWT

### DIFF
--- a/src/app/core/guards/auth.ts
+++ b/src/app/core/guards/auth.ts
@@ -1,0 +1,73 @@
+import { CanActivateFn, CanMatchFn } from '@angular/router';
+import { inject } from '@angular/core';
+import { Router } from '@angular/router';
+import { AuthService } from '@core/services/auth';
+import { map, catchError } from 'rxjs/operators';
+import { of } from 'rxjs';
+
+export const authGuard: CanActivateFn = () => {
+  const authService = inject(AuthService);
+  const router = inject(Router);
+
+  if (authService.isAuthenticated()) {
+    return true;
+  }
+
+  if (authService.checkAuthStatus()) {
+    return authService.autoLogin().pipe(
+      map((success) => {
+        if (success) {
+          return true;
+        } else {
+          return router.createUrlTree(['/auth/signin']);
+        }
+      }),
+      catchError(() => {
+        return of(router.createUrlTree(['/auth/signin']));
+      }),
+    );
+  }
+
+  return router.createUrlTree(['/auth/signin']);
+};
+
+export const authMatchGuard: CanMatchFn = () => {
+  const authService = inject(AuthService);
+
+  if (authService.isAuthenticated()) {
+    return true;
+  }
+
+  if (authService.checkAuthStatus()) {
+    return authService.autoLogin().pipe(
+      map((success) => success),
+      catchError(() => of(false)),
+    );
+  }
+
+  return false;
+};
+
+export const guestGuard: CanActivateFn = () => {
+  const authService = inject(AuthService);
+  const router = inject(Router);
+
+  if (authService.isAuthenticated()) {
+    return router.createUrlTree(['/dashboard']);
+  }
+
+  if (authService.checkAuthStatus()) {
+    return authService.autoLogin().pipe(
+      map((success) => {
+        if (success) {
+          return router.createUrlTree(['/dashboard']);
+        } else {
+          return true;
+        }
+      }),
+      catchError(() => of(true)),
+    );
+  }
+
+  return true;
+};

--- a/src/app/core/interceptors/auth.ts
+++ b/src/app/core/interceptors/auth.ts
@@ -1,21 +1,64 @@
-import { HttpInterceptorFn } from '@angular/common/http';
+import { HttpInterceptorFn, HttpErrorResponse } from '@angular/common/http';
 import { inject } from '@angular/core';
 import { AuthService } from '@core/services/auth';
+import { TokenService } from '@core/services/token';
+import { environment } from '@environments/environment';
+import { catchError, switchMap, throwError } from 'rxjs';
 
-export const auth: HttpInterceptorFn = (req, next) => {
+export const authInterceptor: HttpInterceptorFn = (req, next) => {
   const authService = inject(AuthService);
-  const token = authService.token();
+  const tokenService = inject(TokenService);
 
-  // Si un token est disponible, l'ajouter au header Authorization
-  if (token) {
-    const authReq = req.clone({
-      setHeaders: {
-        Authorization: `Bearer ${token}`,
-      },
+  // Vérifier si c'est un appel vers mon API
+  const isApiCall = req.url.startsWith(environment.apiUrl);
+
+  // Exclu les endpoints d'authentification du refresh automatique
+  const isAuthEndpoint =
+    req.url.includes('/auth/login') ||
+    req.url.includes('/auth/refresh') ||
+    req.url.includes('/auth/logout') ||
+    req.url.includes('/accounts/registration');
+
+  const token = tokenService.getAccessToken();
+  let authReq = req;
+
+  // Pour tous les appels API, inclure withCredentials et le token si disponible
+  if (isApiCall) {
+    authReq = req.clone({
+      setHeaders: token ? { Authorization: `Bearer ${token}` } : {},
+      withCredentials: true, // Important pour les cookies HttpOnly
     });
-    return next(authReq);
   }
 
-  // Sinon, passer la requête sans modification
-  return next(req);
+  return next(authReq).pipe(
+    catchError((error: HttpErrorResponse) => {
+      // Si erreur 401 et pas sur un endpoint d'auth, tenter un refresh
+      if (
+        error.status === 401 &&
+        !isAuthEndpoint &&
+        isApiCall &&
+        tokenService.hasValidRefreshToken()
+      ) {
+        return authService.refreshToken().pipe(
+          switchMap(() => {
+            // Réessayer la requête originale avec le nouveau token
+            const newToken = tokenService.getAccessToken();
+            const retryReq = req.clone({
+              setHeaders: {
+                Authorization: `Bearer ${newToken}`,
+              },
+              withCredentials: true,
+            });
+            return next(retryReq);
+          }),
+          catchError((refreshError) => {
+            // Si le refresh échoue, propager l'erreur
+            return throwError(() => refreshError);
+          }),
+        );
+      }
+
+      return throwError(() => error);
+    }),
+  );
 };

--- a/src/app/core/services/token.ts
+++ b/src/app/core/services/token.ts
@@ -1,0 +1,25 @@
+import { Injectable, signal } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class TokenService {
+  private readonly accessToken = signal<string | null>(null);
+
+  setAccessToken(accessToken: string): void {
+    this.accessToken.set(accessToken);
+  }
+
+  getAccessToken(): string | null {
+    return this.accessToken();
+  }
+
+  clearAccessToken(): void {
+    this.accessToken.set(null);
+  }
+
+  hasValidRefreshToken(): boolean {
+    const userStr = localStorage.getItem('auth_user');
+    return Boolean(userStr && userStr !== 'undefined');
+  }
+}

--- a/src/app/features/auth/models/auth-model.ts
+++ b/src/app/features/auth/models/auth-model.ts
@@ -23,6 +23,10 @@ export interface AuthResponse {
   user: User;
 }
 
+export interface RefreshResponse {
+  access_token: string;
+}
+
 export enum UserRole {
   USER = 'USER',
   ADMIN = 'ADMIN',


### PR DESCRIPTION
- Ajoute `authGuard`, `authMatchGuard` et `guestGuard` pour sécuriser les routes et gérer les redirections
- Crée un `TokenService` dédié à la gestion des tokens en mémoire
- Améliore `AuthService` avec des fonctionnalités d'auto-login, de refresh token et d'initialisation d'état à partir du stockage
- Met à jour l'intercepteur HTTP pour gérer le refresh automatique des tokens et sécuriser les appels API