### PR TITLE
feat(auth): ajoute la gestion du mot de passe oublié et de la réinitialisation

### DIFF
--- a/src/app/core/interceptors/auth.ts
+++ b/src/app/core/interceptors/auth.ts
@@ -32,7 +32,7 @@ export const authInterceptor: HttpInterceptorFn = (req, next) => {
 
   return next(authReq).pipe(
     catchError((error: HttpErrorResponse) => {
-      // Si erreur 401 et pas sur un endpoint d'auth, tenter un refresh
+      // Si erreur 401 n'est pas sur un endpoint auth = refresh
       if (
         error.status === 401 &&
         !isAuthEndpoint &&

--- a/src/app/core/services/auth.ts
+++ b/src/app/core/services/auth.ts
@@ -11,6 +11,10 @@ import {
   User,
   RegistrationResponse,
   VerifyRegistrationRequest,
+  ForgotPasswordRequest,
+  ResetPasswordRequest,
+  ForgotPasswordResponse,
+  ResetPasswordResponse,
 } from '@features/auth/models/auth-model';
 import { ToastService } from '@shared/ui/toast/service/toast';
 import { TokenService } from './token';
@@ -130,6 +134,58 @@ export class AuthService {
             duration: 4000,
             dismissible: true,
           });
+        }),
+        catchError((error) => {
+          this.handleAuthError(error);
+          return throwError(() => error);
+        }),
+      );
+  }
+
+  forgotPassword(request: ForgotPasswordRequest): Observable<ForgotPasswordResponse> {
+    this.setLoading(true);
+    this.clearError();
+
+    return this.http
+      .post<ForgotPasswordResponse>(`${this.baseUrl}/accounts/forgot-password`, request)
+      .pipe(
+        tap((_response) => {
+          this.setLoading(false);
+          this.toastService.show(
+            'success',
+            'Email envoyé',
+            'Si un compte existe avec cette adresse, vous recevrez un lien de réinitialisation',
+            {
+              duration: 6000,
+              dismissible: true,
+            },
+          );
+        }),
+        catchError((error) => {
+          this.handleAuthError(error);
+          return throwError(() => error);
+        }),
+      );
+  }
+
+  resetPassword(request: ResetPasswordRequest): Observable<ResetPasswordResponse> {
+    this.setLoading(true);
+    this.clearError();
+
+    return this.http
+      .post<ResetPasswordResponse>(`${this.baseUrl}/accounts/reset-password`, request)
+      .pipe(
+        tap((_response) => {
+          this.setLoading(false);
+          this.toastService.show(
+            'success',
+            'Mot de passe réinitialisé',
+            'Votre mot de passe a été mis à jour avec succès',
+            {
+              duration: 4000,
+              dismissible: true,
+            },
+          );
         }),
         catchError((error) => {
           this.handleAuthError(error);

--- a/src/app/features/auth/auth-layout.ts
+++ b/src/app/features/auth/auth-layout.ts
@@ -2,12 +2,12 @@ import { ChangeDetectionStrategy, Component, inject, OnInit, signal } from '@ang
 import { NavigationEnd, Router } from '@angular/router';
 import { LayoutComponent } from '@shared/ui/layout/layout';
 import { filter } from 'rxjs/operators';
-import { SigninComponent } from './components/signin';
-import { SignupComponent } from './components/signup';
+import { Signin } from './components/signin/signin';
+import { Signup } from './components/signup/signup';
 
 @Component({
   selector: 'app-auth-layout',
-  imports: [LayoutComponent, SigninComponent, SignupComponent],
+  imports: [LayoutComponent, Signin, Signup],
   template: `
     <app-layout>
       <div

--- a/src/app/features/auth/models/auth-model.ts
+++ b/src/app/features/auth/models/auth-model.ts
@@ -53,3 +53,20 @@ export interface VerifyRegistrationRequest {
 export interface ResendCodeRequest {
   email: string;
 }
+
+export interface ForgotPasswordRequest {
+  email: string;
+}
+
+export interface ResetPasswordRequest {
+  token: string;
+  newPassword: string;
+}
+
+export interface ForgotPasswordResponse {
+  message: string;
+}
+
+export interface ResetPasswordResponse {
+  message: string;
+}

--- a/src/app/features/auth/route/auth.routes.ts
+++ b/src/app/features/auth/route/auth.routes.ts
@@ -11,7 +11,13 @@ export const authRoutes: Routes = [
   },
   {
     path: 'verification',
-    loadComponent: () => import('../components/verification').then((m) => m.VerificationComponent),
+    loadComponent: () =>
+      import('../components/verification/verification').then((m) => m.Verification),
+  },
+  {
+    path: 'reset-password',
+    loadComponent: () =>
+      import('../components/reset-password/reset-password').then((m) => m.ResetPassword),
   },
   {
     path: '',


### PR DESCRIPTION
- Implémente `forgotPassword` et `resetPassword` dans `AuthService`, incluant les requêtes API et les toasts de confirmation
- Ajoute les modèles `ForgotPasswordRequest`, `ResetPasswordRequest`, `ForgotPasswordResponse`, et `ResetPasswordResponse`
- Configure la route `reset-password` et inclut les nouveaux composants associés
- Modernise les chemins et imports des composants d'authentification pour plus de cohérence