### PR TITLE
feat(auth): ajoute le modal de mot de passe oublié

### DIFF
--- a/src/app/features/auth/components/forgot-password/forgot-password.html
+++ b/src/app/features/auth/components/forgot-password/forgot-password.html
@@ -1,0 +1,120 @@
+<div
+  class="w-full max-w-sm mx-auto px-4 py-6 sm:max-w-md sm:px-6 sm:py-8 md:max-w-lg lg:max-w-xl xl:max-w-2xl"
+>
+  <div
+    class="bg-surface border border-border rounded-lg p-6 shadow-sm sm:rounded-xl sm:p-8 md:shadow-lg"
+  >
+    <div class="text-center mb-6 sm:mb-8">
+      <div class="flex justify-center mb-4">
+        <div class="bg-primary/10 p-3 rounded-full">
+          <img
+            [ngSrc]="'/icons/edit_square.svg'"
+            alt="lock"
+            class="w-6 h-6 object-contain icon-invert sm:w-7 sm:h-7 icon-invert"
+            width="24"
+            height="24"
+          />
+        </div>
+      </div>
+      <h2 class="text-2xl font-bold text-text sm:text-3xl md:text-4xl">
+        Mot de passe oublié ?
+      </h2>
+      <p class="text-muted mt-2 text-sm sm:text-base sm:mt-4">
+        Entrez votre adresse email et nous vous enverrons un lien pour réinitialiser votre mot
+        de passe.
+      </p>
+    </div>
+
+    @if (!emailSent()) {
+      <form
+        [formGroup]="forgotPasswordForm"
+        (ngSubmit)="onSubmit()"
+        class="space-y-4 sm:space-y-6"
+      >
+        <div class="space-y-1 sm:space-y-2">
+          <label for="email" class="block text-sm font-medium text-text sm:text-base">
+            Adresse email
+          </label>
+          <input
+            id="email"
+            type="email"
+            formControlName="email"
+            class="w-full px-3 py-2 border rounded-md bg-background text-text placeholder:text-muted focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary transition-all duration-200 sm:px-4 sm:py-3 sm:rounded-lg"
+            [class.border-error]="isFieldInvalid('email')"
+            [class.border-input]="!isFieldInvalid('email')"
+            placeholder="votre@email.com"
+          />
+          @if (isFieldInvalid('email')) {
+            <p class="text-error text-xs mt-1 sm:text-sm">
+              @if (forgotPasswordForm.get('email')?.errors?.['required']) {
+                L'email est requis
+              } @else if (forgotPasswordForm.get('email')?.errors?.['email']) {
+                Veuillez entrer un email valide
+              }
+            </p>
+          }
+        </div>
+
+        <app-button
+          type="submit"
+          color="primary"
+          [disabled]="forgotPasswordForm.invalid"
+          [isLoading]="authService.isLoading()"
+          customClass="w-full py-3 text-base font-semibold mt-6 sm:py-4 sm:text-lg sm:mt-8"
+        >
+          @if (authService.isLoading()) {
+            Envoi en cours...
+          } @else {
+            Envoyer le lien de réinitialisation
+          }
+        </app-button>
+      </form>
+    } @else {
+      <div class="text-center space-y-4">
+        <div class="bg-success/10 border border-success/20 rounded-lg p-4">
+          <div class="flex justify-center mb-3">
+            <div class="bg-success/20 p-2 rounded-full">
+              <img
+                [ngSrc]="'/icons/check.svg'"
+                alt="check"
+                class="w-5 h-5 object-contain icon-invert sm:w-6 sm:h-6 icon-invert"
+                width="20"
+                height="20"
+              />
+            </div>
+          </div>
+          <h3 class="font-semibold text-success mb-2">Email envoyé !</h3>
+          <p class="text-success/80 text-sm">
+            Si un compte existe avec cette adresse email, vous recevrez un lien de
+            réinitialisation dans quelques minutes.
+          </p>
+        </div>
+
+        <button
+          type="button"
+          (click)="resetForm()"
+          class="text-primary hover:text-primary-600 font-medium text-sm transition-colors duration-200 underline-offset-4 hover:underline"
+        >
+          Envoyer à nouveau
+        </button>
+      </div>
+    }
+
+    <div class="mt-6 text-center sm:mt-8">
+      <button
+        type="button"
+        (click)="navigateToSignin()"
+        class="text-muted hover:text-text font-medium text-sm transition-colors duration-200 underline-offset-4 hover:underline flex items-center justify-center gap-2"
+      >
+        <img
+          [ngSrc]="'/icons/arrow-left.svg'"
+          alt="retour"
+          class="w-4 h-4 object-contain icon-invert sm:w-5 sm:h-5 icon-invert"
+          width="16"
+          height="16"
+        />
+        Retour à la connexion
+      </button>
+    </div>
+  </div>
+</div>

--- a/src/app/features/auth/components/forgot-password/forgot-password.ts
+++ b/src/app/features/auth/components/forgot-password/forgot-password.ts
@@ -1,0 +1,57 @@
+import { Component, ChangeDetectionStrategy, inject, signal } from '@angular/core';
+import { FormBuilder, FormGroup, Validators, ReactiveFormsModule } from '@angular/forms';
+import { Router } from '@angular/router';
+import { ButtonComponent } from '@shared/ui/button/button';
+import { AuthService } from '@core/services/auth';
+import { CommonModule, NgOptimizedImage } from '@angular/common';
+
+@Component({
+  selector: 'app-forgot-password',
+  imports: [ReactiveFormsModule, ButtonComponent, CommonModule, NgOptimizedImage],
+  templateUrl: './forgot-password.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ForgotPassword {
+  private readonly fb = inject(FormBuilder);
+  private readonly router = inject(Router);
+  readonly authService = inject(AuthService);
+
+  readonly emailSent = signal(false);
+
+  readonly forgotPasswordForm: FormGroup = this.fb.group({
+    email: ['', [Validators.required, Validators.email]],
+  });
+
+  onSubmit(): void {
+    if (this.forgotPasswordForm.valid) {
+      const email = this.forgotPasswordForm.value.email;
+
+      this.authService.forgotPassword({ email }).subscribe({
+        next: () => {
+          this.emailSent.set(true);
+        },
+        error: () => {
+          // Le service gère déjà l'affichage des erreurs via toast
+          // Mais on peut définir emailSent à true pour des raisons de sécurité
+          // (ne pas révéler si l'email existe ou non)
+          this.emailSent.set(true);
+        },
+      });
+    }
+  }
+
+  resetForm(): void {
+    this.emailSent.set(false);
+    this.forgotPasswordForm.reset();
+    this.forgotPasswordForm.get('email')?.markAsUntouched();
+  }
+
+  isFieldInvalid(fieldName: string): boolean {
+    const field = this.forgotPasswordForm.get(fieldName);
+    return !!(field && field.invalid && field.touched);
+  }
+
+  navigateToSignin(): void {
+    this.router.navigate(['/auth/signin']);
+  }
+}

--- a/src/app/shared/ui/forgot-password-modal/forgot-password-modal-view.ts
+++ b/src/app/shared/ui/forgot-password-modal/forgot-password-modal-view.ts
@@ -1,0 +1,228 @@
+import {
+  Component,
+  ChangeDetectionStrategy,
+  input,
+  output,
+  inject,
+  signal,
+  OnDestroy,
+  effect,
+} from '@angular/core';
+import { FormBuilder, FormGroup, Validators, ReactiveFormsModule } from '@angular/forms';
+import { ButtonComponent } from '@shared/ui/button/button';
+import { AuthService } from '@core/services/auth';
+import type { ForgotPasswordModalData } from './forgot-password-modal';
+import { clearCooldownTimer, startCooldownTimer } from '@shared/utils/cooldown';
+import { NgOptimizedImage } from '@angular/common';
+
+@Component({
+  selector: 'app-forgot-password-modal-view',
+  imports: [ReactiveFormsModule, ButtonComponent, NgOptimizedImage],
+  template: `
+    <div class="fixed inset-0 bg-black/50 backdrop-blur-sm z-40" (click)="onCancel()"></div>
+    <div
+      class="fixed inset-0 z-50 flex items-center justify-center p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Mot de passe oublié"
+    >
+      <div
+        class="relative bg-background border border-border rounded-xl shadow-2xl max-w-md w-full mx-auto overflow-hidden"
+      >
+        <header class="flex items-center justify-between p-6 pb-0">
+          <h2 class="text-xl font-bold text-text">Mot de passe oublié ?</h2>
+          <button
+            type="button"
+            class="p-2 text-muted hover:text-text hover:bg-surface rounded-md transition-colors duration-200"
+            (click)="onCancel()"
+            aria-label="Fermer"
+          >
+            <img [ngSrc]="'/icons/close.svg'" alt="Fermer" class="w-5 h-5" width="24" height="24" />
+          </button>
+        </header>
+
+        <!-- Body -->
+        <section class="p-6">
+          @if (!emailSent()) {
+            <p class="text-center text-muted mb-6 leading-relaxed">
+              Entrez votre adresse email et nous vous enverrons un lien pour réinitialiser votre mot
+              de passe.
+            </p>
+
+            <!-- Form -->
+            <form [formGroup]="forgotPasswordForm" (ngSubmit)="onSubmit()" class="space-y-4">
+              <div class="space-y-1">
+                <label for="email" class="block text-sm font-medium text-text">
+                  Adresse email
+                </label>
+                <input
+                  id="email"
+                  type="email"
+                  formControlName="email"
+                  class="w-full px-4 py-3 border rounded-lg bg-background text-text placeholder:text-muted transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary"
+                  [class.border-error]="isFieldInvalid('email')"
+                  [class.border-input]="!isFieldInvalid('email')"
+                  placeholder="votre@email.com"
+                />
+                @if (isFieldInvalid('email')) {
+                  <p class="text-error text-xs mt-1">
+                    @if (forgotPasswordForm.get('email')?.errors?.['required']) {
+                      L'email est requis
+                    } @else if (forgotPasswordForm.get('email')?.errors?.['email']) {
+                      Veuillez entrer un email valide
+                    }
+                  </p>
+                }
+              </div>
+
+              <app-button
+                type="submit"
+                color="primary"
+                [disabled]="forgotPasswordForm.invalid"
+                [isLoading]="authService.isLoading()"
+                customClass="w-full py-3 text-base font-semibold"
+              >
+                @if (authService.isLoading()) {
+                  Envoi en cours...
+                } @else {
+                  Envoyer le lien de réinitialisation
+                }
+              </app-button>
+            </form>
+          } @else {
+            <!-- Success state -->
+            <div class="text-center space-y-4">
+              <div class="flex justify-center mb-4">
+                <div class="bg-success/10 p-3 rounded-full">
+                  <img
+                    [ngSrc]="'/icons/check.svg'"
+                    alt="Check"
+                    class="w-6 h-6 text-success"
+                    width="24"
+                    height="24"
+                  />
+                </div>
+              </div>
+
+              <div class="bg-success/10 border border-success/20 rounded-lg p-4">
+                <h3 class="font-semibold text-success mb-2">Email envoyé !</h3>
+                <p class="text-success/80 text-sm">
+                  Si un compte existe avec cette adresse email, vous recevrez un lien de
+                  réinitialisation dans quelques minutes.
+                </p>
+              </div>
+
+              <button
+                type="button"
+                (click)="resetForm()"
+                [disabled]="resendCooldown() > 0"
+                class="text-primary hover:text-primary-600 font-medium text-sm transition-colors duration-200 underline-offset-4 hover:underline disabled:opacity-50 disabled:cursor-not-allowed disabled:no-underline"
+              >
+                @if (resendCooldown() > 0) {
+                  Renvoyer dans {{ resendCooldown() }}s
+                } @else {
+                  Envoyer à nouveau
+                }
+              </button>
+            </div>
+          }
+        </section>
+
+        <!-- Footer -->
+        @if (!emailSent()) {
+          <div class="p-6 pt-0 border-t border-border text-center">
+            <button
+              type="button"
+              (click)="onCancel()"
+              class="text-muted hover:text-text font-medium text-sm transition-colors duration-200 underline-offset-4 hover:underline"
+            >
+              Annuler
+            </button>
+          </div>
+        }
+      </div>
+    </div>
+  `,
+  host: {
+    class: 'fixed inset-0 z-50 flex items-center justify-center',
+  },
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ForgotPasswordModalView implements OnDestroy {
+  private readonly fb = inject(FormBuilder);
+  readonly authService = inject(AuthService);
+
+  // Inputs/Outputs
+  readonly data = input<ForgotPasswordModalData>({});
+  readonly emailSubmitted = output<string>();
+  readonly cancelled = output<void>();
+
+  readonly emailSent = signal(false);
+  readonly resendCooldown = signal(0);
+  private cooldownInterval: ReturnType<typeof setInterval> | null = null;
+
+  readonly forgotPasswordForm: FormGroup = this.fb.group({
+    email: ['', [Validators.required, Validators.email]],
+  });
+
+  constructor() {
+    // Utiliser effect pour réagir aux changements de data
+    effect(() => {
+      const modalData = this.data();
+      if (modalData?.email) {
+        this.forgotPasswordForm.patchValue({ email: modalData.email });
+      }
+    });
+  }
+
+  ngOnDestroy(): void {
+    clearCooldownTimer(this.cooldownInterval);
+  }
+
+  onSubmit(): void {
+    if (this.forgotPasswordForm.valid) {
+      const email = this.forgotPasswordForm.value.email;
+
+      this.authService.forgotPassword({ email }).subscribe({
+        next: () => {
+          this.emailSent.set(true);
+          this.emailSubmitted.emit(email);
+          this.startCooldown();
+        },
+        error: () => {
+          // Le service gère déjà l'affichage des erreurs via toast
+          // Mais on peut définir emailSent à true pour des raisons de sécurité
+          // (ne pas révéler si l'email existe ou non)
+          this.emailSent.set(true);
+          this.emailSubmitted.emit(email);
+          this.startCooldown();
+        },
+      });
+    }
+  }
+
+  resetForm(): void {
+    if (this.resendCooldown() > 0) return;
+
+    this.emailSent.set(false);
+    this.forgotPasswordForm.markAsUntouched();
+
+    // Renvoyer l'email
+    if (this.forgotPasswordForm.valid) {
+      this.onSubmit();
+    }
+  }
+
+  onCancel(): void {
+    this.cancelled.emit();
+  }
+
+  isFieldInvalid(fieldName: string): boolean {
+    const field = this.forgotPasswordForm.get(fieldName);
+    return !!(field && field.invalid && field.touched);
+  }
+
+  private startCooldown(): void {
+    this.cooldownInterval = startCooldownTimer(this.resendCooldown, 60);
+  }
+}

--- a/src/app/shared/ui/forgot-password-modal/forgot-password-modal.ts
+++ b/src/app/shared/ui/forgot-password-modal/forgot-password-modal.ts
@@ -1,0 +1,8 @@
+export interface ForgotPasswordModalData {
+  email?: string;
+}
+
+export interface ForgotPasswordModalResult {
+  action: 'sent' | 'cancelled';
+  email?: string;
+}

--- a/src/app/shared/ui/forgot-password-modal/service/forgot-password-modal.ts
+++ b/src/app/shared/ui/forgot-password-modal/service/forgot-password-modal.ts
@@ -1,0 +1,102 @@
+import {
+  Injectable,
+  ApplicationRef,
+  createComponent,
+  EnvironmentInjector,
+  signal,
+  ComponentRef,
+  inject,
+  Type,
+} from '@angular/core';
+import { ForgotPasswordModalView } from '../forgot-password-modal-view';
+import type { ForgotPasswordModalData } from '../forgot-password-modal';
+
+// Minimal typings to avoid `any`
+type SubscriptionLike = { unsubscribe: () => void };
+interface Subscribable<T> {
+  subscribe: (cb: (value: T) => void) => SubscriptionLike;
+}
+
+interface ForgotPasswordModalComponent {
+  emailSubmitted: Subscribable<string>;
+  cancelled: Subscribable<void>;
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class ForgotPasswordModalService {
+  private modalComponentRef: ComponentRef<ForgotPasswordModalComponent> | null = null;
+  private readonly modalStack = signal<ComponentRef<ForgotPasswordModalComponent>[]>([]);
+
+  private readonly appRef = inject(ApplicationRef);
+  private readonly injector = inject(EnvironmentInjector);
+
+  async showForgotPasswordModal(data: ForgotPasswordModalData): Promise<{
+    email?: string;
+    cancelled?: boolean;
+  }> {
+    return new Promise<{ email?: string; cancelled?: boolean }>((resolve) => {
+      const modalRef = createComponent(
+        ForgotPasswordModalView as unknown as Type<ForgotPasswordModalComponent>,
+        {
+          environmentInjector: this.injector,
+        }
+      );
+
+      modalRef.setInput('data', data);
+      const instance = modalRef.instance as ForgotPasswordModalComponent;
+
+      // Handle email submission
+      const emailSubscription = instance.emailSubmitted.subscribe((email: string) => {
+        emailSubscription.unsubscribe();
+        this.closeModal(modalRef);
+        resolve({ email });
+      });
+
+      // Handle cancellation
+      const cancelSubscription = instance.cancelled.subscribe(() => {
+        cancelSubscription.unsubscribe();
+        this.closeModal(modalRef);
+        resolve({ cancelled: true });
+      });
+
+      this.showModal(modalRef);
+      this.modalComponentRef = modalRef;
+    });
+  }
+
+  private showModal(modalRef: ComponentRef<ForgotPasswordModalComponent>): void {
+    this.appRef.attachView(modalRef.hostView);
+
+    const modalElement = modalRef.location.nativeElement as HTMLElement;
+    document.body.appendChild(modalElement);
+
+    this.modalStack.update((stack) => [...stack, modalRef]);
+    document.body.style.overflow = 'hidden';
+  }
+
+  private closeModal(modalRef: ComponentRef<ForgotPasswordModalComponent>): void {
+    this.modalStack.update((stack) => stack.filter((ref) => ref !== modalRef));
+
+    this.appRef.detachView(modalRef.hostView);
+
+    const modalElement = modalRef.location.nativeElement as HTMLElement;
+    modalElement?.parentNode?.removeChild(modalElement);
+
+    modalRef.destroy();
+
+    if (this.modalStack().length === 0) {
+      document.body.style.overflow = '';
+    }
+
+    if (this.modalComponentRef === modalRef) {
+      this.modalComponentRef = null;
+    }
+  }
+
+  closeAllModals(): void {
+    const modals = [...this.modalStack()];
+    modals.forEach((modalRef) => this.closeModal(modalRef));
+  }
+}


### PR DESCRIPTION
- Implémente `ForgotPasswordModalService` pour gérer l'ouverture, la fermeture et les réponses du modal
- Ajoute le composant `ForgotPassword` et son template pour envoyer des liens de réinitialisation
- Intègre le modal au processus existant avec des interactions utilisateur fluides
- Stylise les vues pour correspondre au design global et améliorer l'accessibilité