### PR TITLE
chore(env): ajoute les fichiers dotenv et paths à gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,10 @@ testem.log
 # System files
 .DS_Store
 Thumbs.db
+
+# Environment variables (dotenv)
+.env
+.env.*
+!.env.example
+!.env.*.example
+/src/environments


### PR DESCRIPTION
- Ignore les fichiers `.env`, `.env.*` et le dossier `/src/environments` pour protéger les informations sensibles
- Exclut `.env.example` et `.env.*.example` pour conserver les exemples de configuration