### PR TITLE
chore(env): simplifie les règles d'ignoring pour les environnements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,9 +41,5 @@ testem.log
 .DS_Store
 Thumbs.db
 
-# Environment variables (dotenv)
-.env
-.env.*
-!.env.example
-!.env.*.example
-/src/environments
+# Environments
+src/environments/*


### PR DESCRIPTION
- Regroupe les exclusions des fichiers d'environnement sous une règle unique
- Ignore tous les fichiers du dossier `src/environments` pour protéger les données sensibles