### PR TITLE
fix(jobtrack): convert appliedAt date-only input to ISO datetime

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,5 @@
+allowBuilds:
+  '@parcel/watcher': set this to true or false
+  esbuild: set this to true or false
+  lmdb: set this to true or false
+  msgpackr-extract: set this to true or false

--- a/src/app/features/jobtrack/application/components/jobtrack-form/jobtrack-form.ts
+++ b/src/app/features/jobtrack/application/components/jobtrack-form/jobtrack-form.ts
@@ -28,6 +28,7 @@ import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angula
 import { Toaster } from '@shared/ui/toast/service/toast';
 import { Icon } from '@shared/ui/icon/icon';
 import { PdfViewerModal } from '@shared/ui/pdf-viewer-modal/pdf-viewer-modal';
+import { dateOnlyToIso } from '@shared/utils/date-only-to-iso';
 
 type JobtrackForm = {
   title: FormControl<string>;
@@ -493,7 +494,7 @@ export class JobtrackFormPage implements OnInit {
       if (value.company) updatePayload.company = value.company;
       if (value.jobUrl) updatePayload.jobUrl = value.jobUrl;
       if (value.contractType) updatePayload.contractType = value.contractType;
-      if (value.appliedAt) updatePayload.appliedAt = value.appliedAt;
+      if (value.appliedAt) updatePayload.appliedAt = dateOnlyToIso(value.appliedAt);
       if (value.notes) updatePayload.notes = value.notes;
 
       this.jobtrackGateway.updateWithReminder(jobId!, updatePayload, false).subscribe({
@@ -524,7 +525,7 @@ export class JobtrackFormPage implements OnInit {
       if (value.company) createPayload.company = value.company;
       if (value.jobUrl) createPayload.jobUrl = value.jobUrl;
       if (value.contractType) createPayload.contractType = value.contractType;
-      if (value.appliedAt) createPayload.appliedAt = value.appliedAt;
+      if (value.appliedAt) createPayload.appliedAt = dateOnlyToIso(value.appliedAt);
       if (value.notes) createPayload.notes = value.notes;
 
       this.jobtrackGateway.createWithReminder(createPayload).subscribe({

--- a/src/app/shared/utils/date-only-to-iso.spec.ts
+++ b/src/app/shared/utils/date-only-to-iso.spec.ts
@@ -1,0 +1,26 @@
+import { dateOnlyToIso } from './date-only-to-iso';
+
+describe('dateOnlyToIso', () => {
+  it('should convert a date-only string (YYYY-MM-DD) to a full ISO datetime string', () => {
+    // Given
+    const dateOnly = '2026-08-23';
+
+    // When
+    const result = dateOnlyToIso(dateOnly);
+
+    // Then
+    expect(result).toBe('2026-08-23T00:00:00.000Z');
+  });
+
+  it('should produce a string accepted by the same ISO datetime regex the backend validates against', () => {
+    // Given
+    const dateOnly = '2026-01-05';
+    const isoDatetimeRegex = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z$/;
+
+    // When
+    const result = dateOnlyToIso(dateOnly);
+
+    // Then
+    expect(result).toMatch(isoDatetimeRegex);
+  });
+});

--- a/src/app/shared/utils/date-only-to-iso.ts
+++ b/src/app/shared/utils/date-only-to-iso.ts
@@ -1,0 +1,4 @@
+// Backend Zod schema requires a full ISO datetime, not a date-only string from <input type="date">
+export function dateOnlyToIso(dateOnly: string): string {
+  return new Date(dateOnly).toISOString();
+}


### PR DESCRIPTION
## Summary
- La création/modification d'une annonce échouait en 400 dès que la « Date de ma candidature » était renseignée : `<input type="date">` envoie une chaîne date-only (`YYYY-MM-DD`), mais le schéma Zod backend (`appliedAt: z.string().datetime()`) exige un ISO 8601 complet avec heure.
- Ajout de `dateOnlyToIso()` (utilitaire pur, testé) et utilisation dans `jobtrack-form.ts` aux deux points d'envoi (création et modification).

## Test plan
- [x] Nouveau test unitaire `date-only-to-iso.spec.ts` (RED confirmé avant l'implémentation, GREEN après)
- [x] Suite complète : 38/38 tests verts
- [x] `ng build` OK
- [x] ESLint propre sur les fichiers modifiés